### PR TITLE
bug fix: set bazel to bazel_path if non empty

### DIFF
--- a/src/scripts/prerequisites.sh
+++ b/src/scripts/prerequisites.sh
@@ -37,6 +37,11 @@ if [[ ${BAZEL_PATH} == "bazel" ]]; then
 	fi
 fi
 
+# set bazel to BAZEL_PATH if non-empty
+if [ -n "${BAZEL_PATH+x}" ]; then
+	bazel=${BAZEL_PATH}
+fi
+
 changes_count=0
 impacts_all_detected="false"
 if [[ -n ${IMPACTS_FILTERS_CHANGES+x} ]]; then


### PR DESCRIPTION
This PR fixes a bug where bazel isn't installed locally, but we pass a valid path to a bazel wrapper. 

in `prerequisites.sh`, we use 
```
_java=$(bazel info java-home)/bin/java
```

However, if bazel isn't installed locally, this command fails

![image](https://github.com/Ryang20718/bazel-action/assets/31294356/9099d701-8e78-4916-9a23-ac4d81785c5f)
